### PR TITLE
Replace ixdotai/smtp with boky/postfix

### DIFF
--- a/github-runner/docker-compose.yml
+++ b/github-runner/docker-compose.yml
@@ -58,8 +58,10 @@ services:
             - traefik.enable=false
 
     smtp-server:
-        image: ixdotai/smtp:latest
+        image: boky/postfix:latest
         restart: always
+        environment:
+            ALLOWED_SENDER_DOMAINS: ${ALLOWED_SENDER_DOMAINS:-shopsys.com}
         networks:
             - default
         labels:


### PR DESCRIPTION
## Summary

- `ixdotai/smtp` is no longer maintained; swap to `boky/postfix:latest`, the actively-maintained equivalent.
- Same direct DNS MX delivery behaviour, no credentials required.
- Adds the new env var `ALLOWED_SENDER_DOMAINS` (defaulted to `shopsys.com`) — required by `boky/postfix` since open-relay is no longer permitted out of the box.

## Background

Related to shopsys/shopsys#4609, which already swaps the in-repo `docker-compose*.yml.dist` templates from `ixdotai/smtp` (and `namshi/smtp` for the labelled review variant) to maintained equivalents. The host-runner shared SMTP container defined here is the one that backs review deployments using the simplified compose, so it also needs to move off the unmaintained image.